### PR TITLE
Pin hdf5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,21 @@ env:
     - secure: "XsNBSTdSlhwP7iqCBRAqHWxrJfays+2I+c6dXrkhZpPB85Ql1UH7t3T3e/N7OkxQmwBMHV9qATh87JHxaOoDkNoelOe2BmK4nLEDQS+S1s0pfcNlCJ38e7TWmtRMBfTYDH9vB3T+vUPkPDSqDFHkmg4MJXv6RZN473fUfnIkFKXT26X7otj3OPa5a/dMkgA+jovx9yFL+lxdakyt5t/bAqI433H2zqYZhqODCTggALpPoHolcXe3t2wAZO4Z7QE7g7XIMDbwDfYtG+Ql2PRYP+yg8nFJsUYmhQTRY75fbusOGOurgejrF2E/zmh/LCeho6fvbEvaP7cjnhUWil9hZc0BJ2k475ZAY0IJ4PsEMU3QGm2aniwMbqleYujTX1UeyTr9MdjKX+5aSIUJrkh/5zpodM0WxHFgsSJnhPsRZtovJ3QyLG7LMbpxkd6N2Dqs93m+NnLjFjAgvFGRFbgaThy5YTtxcqeXFn0WcdVe4YDBa35UDtAKpicESSrcVSjSn7wizWzv2CmRRQNV/5HTvbSUWg0IkfsmOMjrc3gdXz4pmFK56zck110aTNkC2YGLGG/rkSe+XzZVYyiAvjJP0+k6wt9LslT/2RQeilTvaPY2Zh7DGWYtJ4SvcBpB5hEmPzOZHDMkyGbLQ62LbN+ACOzbxAR/pHTIu0X7MDFFvg8="
 
 
+before_install:
+    - brew remove --force $(brew list)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://www.cs.ubc.ca/research/flann/
 
 Package license: BSD 3-Clause
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: The Fast Library for Approximate Nearest Neighbors
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,11 @@ build:
 requirements:
     build:
         - gcc     # [osx]
-        - hdf5
+        - hdf5 1.8.15*
         - cmake
     run:
         - libgcc  # [osx]
-        - hdf5
+        - hdf5 1.8.15*
 
 test:
     commands:


### PR DESCRIPTION
Unless `flann` needs latest `hdf5 1.8.16` this ensures that `flann` plays nice with the packages in `conda-forge` and the default channel.

Closes #2 
