### PR TITLE
Bump to version 1.8.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
     md5: 774b74580e3cbc5b0d45c6ec345a64ae
 
 build:
-    number: 2
+    number: 3
     skip: true    # [win]
 
 requirements:
     build:
         - gcc     # [unix]
-        - hdf5 1.8.17*
+        - hdf5 1.8.17|1.8.17.*
         - cmake
     run:
         - libgcc  # [unix]
-        - hdf5 1.8.17*
+        - hdf5 1.8.17|1.8.17.*
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.4" %}
+{% set version = "1.8.5" %}
 
 package:
     name: flann
@@ -7,20 +7,20 @@ package:
 source:
     fn: flann-{{ version }}.tar.gz
     url: https://github.com/mariusmuja/flann/archive/{{ version }}.tar.gz
-    md5: 774b74580e3cbc5b0d45c6ec345a64ae
+    sha256: 59a9925dac0705b281496ae52b5dfd79d6b69316d37015e3d3b38c859bac4f2f
 
 build:
-    number: 2
+    number: 0
     skip: true    # [win]
 
 requirements:
     build:
         - gcc     # [unix]
-        - hdf5 1.8.17*
+        - hdf5 1.8.17|1.8.17.*
         - cmake
     run:
         - libgcc  # [unix]
-        - hdf5 1.8.17*
+        - hdf5 1.8.17|1.8.17.*
 
 test:
     commands:


### PR DESCRIPTION
Closes https://github.com/conda-forge/flann-feedstock/pull/10

This simply bumps the version to 1.8.5. Also, goes ahead and updates how the pinnings are done as well. Though the actual versions pinned are effectively the same.
