### PR TITLE
Cleanup URLs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @traversaro @djsutherland @jakevdp @jakirkham @seanyen
+* @djsutherland @jakevdp @jakirkham @seanyen @traversaro

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About flann-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/flann-feedstock/blob/main/LICENSE.txt)
 
-Home: http://www.cs.ubc.ca/research/flann/
+Home: https://github.com/flann-lib/flann/
 
 Package license: BSD-3-Clause
 
@@ -201,4 +201,5 @@ Feedstock Maintainers
 * [@jakevdp](https://github.com/jakevdp/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@seanyen](https://github.com/seanyen/)
+* [@traversaro](https://github.com/traversaro/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
 
 source:
     fn: flann-{{ version }}.tar.gz
-    url: https://github.com/mariusmuja/flann/archive/{{ version }}.tar.gz
+    url: https://github.com/flann-lib/flann/archive/{{ version }}.tar.gz
     sha256: b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3
     patches:
         # CMake 3.11 breaks FLANN's existing src/cpp/CMakeLists.txt. See
-        # https://github.com/mariusmuja/flann/issues/369 for more information.
+        # https://github.com/flann-lib/flann/issues/369 for more information.
         - src-cpp-fix-cmake-3.11-build.patch
         # This serializer workaround for VS 2013 doesn't work correctly in VC9.
         - remove-serializer-workaround.patch
@@ -47,7 +47,7 @@ test:
         - if not exist %PREFIX%\\Library\\include\\flann exit 1      # [win]
 
 about:
-    home: http://www.cs.ubc.ca/research/flann/
+    home: https://github.com/flann-lib/flann/
     license: BSD-3-Clause
     license_file: COPYING
     summary: "The Fast Library for Approximate Nearest Neighbors"


### PR DESCRIPTION
The GitHub repo has been moved to https://github.com/flann-lib/flann, and the webpage has not been working since ~3 years ago: https://github.com/flann-lib/flann/issues/440 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
